### PR TITLE
Phase 1 – Clean Plugin Upload (No Secrets)

### DIFF
--- a/burnnote-io.css
+++ b/burnnote-io.css
@@ -4,43 +4,70 @@ Font Import
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&display=swap');
 
 /* ---------------------------------------------------
+Hero Section Background
+--------------------------------------------------- */
+.burnnote-hero {
+  background-color: #E6F6F3;
+  padding: 4rem 1rem;
+}
+
+/* ---------------------------------------------------
 Container Styles (Shared)
 --------------------------------------------------- */
 .burnnote-container {
   font-family: 'IBM Plex Sans', sans-serif;
-  background-color: #F9FAFB;
-  padding: 2rem;
-  border-radius: 12px;
+  background-color: #4FBFA2;
+  padding: 2.5rem;
+  border-radius: 16px;
   max-width: 640px;
-  margin: 3rem auto;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.05);
-  border: 1px solid #e5e7eb;
+  margin: 0 auto;
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.06);
+  border: none;
+  position: relative;
 }
+
 .burnnote-container a {
   display: inline-block;
   font-weight: 500;
   margin-top: 1.5rem;
   text-align: center;
 }
-/* ---------------------------------------------------
-Headings
---------------------------------------------------- */
-.burnnote-container h1,
-.burnnote-container h2 {
-  font-weight: 600;
-  font-size: 2rem;
-  margin-bottom: 1rem;
-  color: #0B2948;
-}
 
 /* ---------------------------------------------------
-Subtext (for password screen)
+Header Section with Icon
 --------------------------------------------------- */
-.burnnote-subtext {
-  color: #4B5563;
-  font-size: 0.95rem;
-  margin-bottom: 1.25rem;
+.burnnote-header {
+  text-align: center;
+  margin-bottom: 1.5rem;
 }
+
+.burnnote-header .burnnote-icon {
+  display: inline-block;
+  width: 48px;
+  height: 48px;
+  background: url('https://burnnote.io/wp-content/uploads/2025/06/burnnote-lock-icon-blue.png') no-repeat center center;
+  background-size: contain;
+  margin: 0 auto 1rem;
+}
+
+.burnnote-header h2 {
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: #ffffff;
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.burnnote-header .burnnote-subtext {
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 400;
+  margin-top: -0.5rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+  opacity: 0.95;
+}
+
 
 /* ---------------------------------------------------
 Textarea (Message Input)
@@ -50,7 +77,7 @@ Textarea (Message Input)
   width: 100%;
   padding: 1rem;
   border: 1px solid #d0d7df;
-  border-radius: 8px;
+  border-radius: 10px;
   resize: vertical;
   font-size: 1rem;
   background: #ffffff;
@@ -58,38 +85,19 @@ Textarea (Message Input)
   line-height: 1.4;
   font-family: inherit;
   box-sizing: border-box;
+  margin-bottom: 1rem;
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .burnnote-container textarea::placeholder {
   color: #94a3b8;
 }
 
-.burnnote-container textarea:focus {
+.burnnote-container textarea:focus,
+.burnnote-password-field:focus {
   outline: none;
   border-color: #4FBFA2;
-  box-shadow: 0 0 0 2px rgba(79, 191, 162, 0.25);
-}
-
-@media screen and (max-width: 480px) {
-  .burnnote-container textarea,
-  .burnnote-password-field {
-    width: 100%;
-  }
-}
-
-/* ---------------------------------------------------
-Password Field Input
---------------------------------------------------- */
-.burnnote-password-field {
-  padding: 0.75rem 1rem;
-  width: 100%;
-  border: 1px solid #D1D5DB;
-  border-radius: 6px;
-  font-size: 1rem;
-  margin-bottom: 1rem;
-  font-family: 'IBM Plex Sans', sans-serif;
-  background-color: #fff;
-  color: #0B2948;
+  box-shadow: 0 0 0 3px rgba(79, 191, 162, 0.25);
 }
 
 /* ---------------------------------------------------
@@ -97,13 +105,13 @@ Submit Button (both pages)
 --------------------------------------------------- */
 .burnnote-submit-btn,
 .burnnote-container button[type="submit"] {
-  background-color: #4FBFA2;
+  background-color: #0B2948;
   color: white;
   font-weight: 600;
   border: none;
   padding: 0.75rem 1.5rem;
   font-size: 1rem;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   transition: background-color 0.2s ease;
   letter-spacing: 0.3px;
@@ -112,7 +120,7 @@ Submit Button (both pages)
 
 .burnnote-submit-btn:hover,
 .burnnote-container button[type="submit"]:hover {
-  background-color: #3AA38A;
+  background-color: #1B3C63;
 }
 
 /* ---------------------------------------------------
@@ -123,7 +131,7 @@ Copy Link Styles
   border-left: 4px solid #4FBFA2;
   padding: 1rem;
   border-radius: 6px;
-  margin-top: 1rem;
+  margin-top: 1.5rem;
 }
 
 .burnnote-link-box label {
@@ -151,7 +159,7 @@ Copy Link Styles
 }
 
 #burnnote-copy-btn {
-  background-color: #4FBFA2;
+  background-color: #0B2948;
   color: #fff;
   border: none;
   font-weight: 600;
@@ -164,16 +172,20 @@ Copy Link Styles
 }
 
 #burnnote-copy-btn:hover {
-  background-color: #3AA38A;
+  background-color: #1B3C63;
 }
 
 /* ---------------------------------------------------
 Mobile Responsiveness
 --------------------------------------------------- */
 @media screen and (max-width: 480px) {
+  .burnnote-hero {
+    padding: 2rem 1rem;
+  }
+
   .burnnote-container {
-    padding: 1rem;
-    margin: 1rem;
+    padding: 1.5rem;
+    margin: 0 1rem;
   }
 
   .burnnote-container textarea,
@@ -192,4 +204,34 @@ Mobile Responsiveness
     flex-direction: column;
     gap: 0.75rem;
   }
+}
+
+/* ---------------------------------------------------
+Link Display
+--------------------------------------------------- */
+.burnnote-newnote-link {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.burnnote-newnote-link a {
+  color: #ffffff;
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+/* ---------------------------------------------------
+Message
+--------------------------------------------------- */
+.burnnote-message-body {
+  margin: 1.5rem 0;
+}
+
+.burnnote-message-text {
+  font-size: 1.25rem;
+  color: #0B2948;
+  font-weight: 500;
+  text-align: center;
+  line-height: 1.6;
+  margin: 1rem 0;
 }

--- a/templates/already-viewed.php
+++ b/templates/already-viewed.php
@@ -6,7 +6,7 @@
     <?php wp_head(); ?>
 </head>
 <body>
-    <div class="burnnote-container">
+    <div class="burnnote-header">
         <h2>Note Already Viewed</h2>
         <p class="burnnote-subtext">This note has already been viewed and is no longer available.</p>
         <a href="<?php echo site_url(); ?>" style="display:inline-block;margin-top:1rem;color:#4FBFA2;text-decoration:underline;">← Create a new note</a>

--- a/templates/form.php
+++ b/templates/form.php
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html>
 <head>
@@ -6,38 +7,75 @@
     <?php wp_head(); ?>
 </head>
 <body>
-    <div class="burnnote-container">
-        <h2>BurnNote</h2>
-        <form method="post" autocomplete="off">
-           <textarea 
-    		name="burnnote_message" 
-    		rows="5" 
-    		placeholder="Enter your private message..." 
-    		required></textarea>
-
-            
-            <!-- Honeypot field to catch bots -->
-            <input 
-                type="text" 
-                name="username" 
-                autocomplete="off" 
-                style="display:none" 
-                aria-hidden="true"
-            >
-            
-            <input 
-                type="password" 
-                name="new_burnnote_password" 
-                placeholder="Optional password (leave blank for none)" 
-                class="burnnote-password-field" 
-                autocomplete="new-password"
-            >
-            
-            <button type="submit" class="burnnote-submit-btn">
-                Create Private Link
-            </button>
-        </form>
+<div class="burnnote-container">
+  <div class="burnnote-header">
+    <div class="burnnote-icon" role="img" aria-label="Secure lock icon"></div>
+      <h2>Secure Notes That Self-Destruct</h2>
+      <p class="burnnote-subtext">Create encrypted, one-time messages for sharing sensitive information safely.</p>
     </div>
-    <?php wp_footer(); ?>
+
+    <form method="post" id="burnnote-form" autocomplete="off" novalidate>
+      <textarea 
+          name="burnnote_message" 
+          rows="5" 
+          placeholder="Enter your private message..." 
+          required></textarea>
+
+      <!-- Honeypot -->
+      <input 
+          type="text" 
+          name="username" 
+          autocomplete="off" 
+          style="display:none" 
+          aria-hidden="true"
+      >
+
+      <input 
+          type="password" 
+          name="new_burnnote_password" 
+          placeholder="Optional password (leave blank for none)" 
+          class="burnnote-password-field" 
+          autocomplete="new-password"
+      >
+
+      <!-- Hidden input to hold token -->
+      <input type="hidden" name="cf-turnstile-response" id="cf-turnstile-response">
+
+      <!-- Invisible Turnstile widget with explicit ID -->
+      <div 
+          class="cf-turnstile" 
+          id="cf-turnstile"
+          data-sitekey="0x4AAAAAABg6XqsLoYvl5HNT" 
+          data-callback="onTurnstileSuccess"
+          data-theme="light"
+          data-size="invisible">
+      </div>
+
+      <button type="submit" class="burnnote-submit-btn">
+          Create Private Link
+      </button>
+    </form>
+  </div>
+
+  <script data-cfasync="false">
+      let formSubmittedByUser = false;
+
+      function onTurnstileSuccess(token) {
+          if (!formSubmittedByUser) return;
+          document.getElementById('cf-turnstile-response').value = token;
+          document.getElementById('burnnote-form').submit();
+      }
+
+      document.getElementById('burnnote-form').addEventListener('submit', function (e) {
+          const token = document.getElementById('cf-turnstile-response').value;
+
+          if (!token) {
+              e.preventDefault();
+              formSubmittedByUser = true;
+              turnstile.execute(document.getElementById('cf-turnstile'));
+          }
+      });
+  </script>
+  <?php wp_footer(); ?>
 </body>
 </html>

--- a/templates/link-display.php
+++ b/templates/link-display.php
@@ -2,11 +2,11 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <title>BurnNote | Your Private Link</title>
-  <?php wp_head(); ?>
+  <title>Secure Link Created | BurnNote</title>
+   <?php wp_head(); ?>
 </head>
 <body>
-  <div class="burnnote-container">
+<!-- <div class="burnnote-container">
     <h2>Your Private Link</h2>
     <div class="burnnote-link-box">
       <label for="burnnote-generated-link">Copy and share this link:</label>
@@ -16,10 +16,35 @@
       </div>
     </div>
     <div style="text-align: center; margin-top: 2rem;">
-      <a href="<?php echo esc_url(get_permalink()); ?>" style="color:#4FBFA2; text-decoration: underline;">← Make a new note</a>
+      <a href="<?php echo esc_url(get_permalink()); ?>" style="color:#fff; text-decoration: underline;">← Make a new note</a>
+    </div>
+  </div>
+-->
+  
+<!-- NEW -->
+  
+<div class="burnnote-container">
+  <div class="burnnote-header">
+    <div class="burnnote-icon" role="img" aria-label="Secure lock icon"></div>
+    <h2>Your Private Link</h2>
+    <p class="burnnote-subtext" id="note-description">Send this secure note before it disappears.</p>
+  </div>
+
+  <div class="burnnote-link-box">
+    <label for="burnnote-generated-link">Copy and share this link:</label>
+    <div class="burnnote-link-row">
+      <input id="burnnote-generated-link" type="text" value="<?php echo esc_url($link); ?>" readonly>
+      <button type="button" id="burnnote-copy-btn">Copy</button>
     </div>
   </div>
 
+  <div class="burnnote-newnote-link">
+    <a href="<?php echo esc_url(get_permalink()); ?>">← Make a new note</a>
+  </div>
+</div>
+
+<!-- END NEW -->
+  
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       const copyBtn = document.getElementById('burnnote-copy-btn');

--- a/templates/message-view.php
+++ b/templates/message-view.php
@@ -1,16 +1,27 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="UTF-8">
-  <title>BurnNote | Your Message</title>
-  <?php wp_head(); ?>
+    <meta charset="UTF-8">
+    <title>BurnNote | Your Message</title>
+	<?php wp_head(); ?>
 </head>
 <body>
   <div class="burnnote-container">
-    <h2>Your Message:</h2>
-    <p><?php echo $message; ?></p>
-    <p class="burnnote-subtext"><em>This note has now been deleted.</em></p>
-    <a href="<?php echo esc_url(site_url()); ?>" style="display:inline-block;margin-top:1rem;color:#4FBFA2;text-decoration:underline;">← Make a new note</a>
+    <div class="burnnote-header">
+      <div class="burnnote-icon" role="img" aria-label="Secure lock icon"></div>
+      <h2>Your Message</h2>
+      <p class="burnnote-subtext"><em>This note will now been burned.</em></p>
+    </div>
+
+    <div class="burnnote-message-body">
+	<p>
+		<?php echo nl2br(esc_html($message)); ?>
+	</p>
+    </div>
+
+    <div class="burnnote-newnote-link">
+      <a href="<?php echo esc_url(site_url()); ?>">← Make a new note</a>
+    </div>
   </div>
   <?php wp_footer(); ?>
 </body>


### PR DESCRIPTION
Clean re-upload of the BurnNote plugin Phase 1 work:

- View-once message deletion
- Cloudflare Turnstile (secret moved to wp-config.php)
- Robots.txt and meta noindex for secure links
- “Click to Reveal” UX
- Brand styling (IBM Plex Sans, #0B2948, #4FBFA2)

Confirmed no secrets present in this commit.
